### PR TITLE
Remove noop comment block and use a simple macro

### DIFF
--- a/CVE-2017-6074/poc.c
+++ b/CVE-2017-6074/poc.c
@@ -54,6 +54,8 @@
 #include <linux/if_packet.h>
 #include <netinet/if_ether.h>
 
+#define DEBUG_FLAG		0
+#define NOOP			((void)0)
 #define SMEP_SMAP_BYPASS	1
 
 // Needed for local root.
@@ -76,11 +78,13 @@
 static int port = 11000;
 
 void debug(const char *msg) {
-/*
+#if DEBUG_FLAG
 	char buffer[32];
 	snprintf(&buffer[0], sizeof(buffer), "echo '%s' > /dev/kmsg\n", msg);
 	system(buffer);
-*/
+#else
+	NOOP;
+#endif
 }
 
 // * * * * * * * * * * * * * * Kernel structs * * * * * * * * * * * * * * * *


### PR DESCRIPTION
Instead of using a comment block for the noop just use a simple macro for debug.